### PR TITLE
Show route name optionally in activity banner

### DIFF
--- a/src/components/Common/ActivityBanner.js
+++ b/src/components/Common/ActivityBanner.js
@@ -5,7 +5,7 @@ const PlacesBanner = ({ route, image, onLike, activityId }) => {
     // get initial like value from localStorage
 
     const [liked, setLiked] = useState(false);
-    const { routeColorName } = route;
+    const routeColorName = route?.routeColorName;
 
     const colors = {
         violet: "text-violet-900 border-violet-900",
@@ -58,19 +58,23 @@ const PlacesBanner = ({ route, image, onLike, activityId }) => {
                 />
             </button>
 
-            <div className="absolute flex top-8 right-8 items-center bg-white px-2 py-0.5 rounded-md shadow-md">
-                <Icon
-                    name="route"
-                    size={4}
-                    className={`mr-1 ${colors[routeColorName.toLowerCase()]}`}
-                />
-                <span
-                    className={`uppercase font-semibold text-sm ${
-                        colors[routeColorName.toLowerCase()]
-                    }`}>
-                    {routeColorName} Route
-                </span>
-            </div>
+            {routeColorName && (
+                <div className="absolute flex top-8 right-8 items-center bg-white px-2 py-0.5 rounded-md shadow-md">
+                    <Icon
+                        name="route"
+                        size={4}
+                        className={`mr-1 ${
+                            colors[routeColorName?.toLowerCase()]
+                        }`}
+                    />
+                    <span
+                        className={`uppercase font-semibold text-sm ${
+                            colors[routeColorName.toLowerCase()]
+                        }`}>
+                        {routeColorName} Route
+                    </span>
+                </div>
+            )}
 
             <button
                 className="absolute flex items-center justify-center -bottom-0 right-8 w-14 h-14 bg-white shadow-lg rounded-full focus:outline-none"


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Kites-hackathon-squad"
-->

### Fixes #138 

The activity **KSRTC Sightseeing** throws an in the ActivityBanner component because there is no route id / `routeColorName` associated with it.

This PR fixes makes the `routeColorName` an optional value. Which is shown if present or else ignored.

## Does this PR introduce a breaking change

No
