### PR TITLE
Change behaviour of booking button

### DIFF
--- a/src/components/Common/Heading.js
+++ b/src/components/Common/Heading.js
@@ -106,7 +106,8 @@ const Heading = ({ place, className }) => {
                     </a>
                 )}
 
-                {bookingDetails && (
+                {(bookingDetails?.bookingContactNumber ||
+                    bookingDetails?.bookingLink) && (
                     <>
                         <button
                             onClick={() => setShowBookingModal(true)}


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Kites-hackathon-squad"
-->

# Closes #146

The **booking** button is shown only if the bookingDetails object contains either `bookingLink` or `bookingContactNumber`

### Does this PR introduce a breaking change

No
