### PR TITLE
chore: fixed back navigation on experiences tab

### DIFF
--- a/src/components/Common/ActivityBanner.js
+++ b/src/components/Common/ActivityBanner.js
@@ -49,7 +49,11 @@ const ActivityBanner = ({ route, image, onLike, activityId }) => {
             />
             <button
                 className="absolute flex bg-white items-center shadow-md justify-center left-8 top-8 w-8 h-8 rounded-full focus:outline-none"
-                onClick={() => navigate("/")}>
+                onClick={() =>
+                    window.history.length === 1
+                        ? navigate("/")
+                        : window.history.back()
+                }>
                 <Icon
                     name="caretLeft"
                     color="black"

--- a/src/components/Common/PlacesBanner.js
+++ b/src/components/Common/PlacesBanner.js
@@ -50,7 +50,11 @@ const PlacesBanner = ({ route, image, onLike, destinationId }) => {
             />
             <button
                 className="absolute flex bg-white items-center shadow-md justify-center left-8 top-8 w-8 h-8 rounded-full focus:outline-none"
-                onClick={() => navigate("/")}>
+                onClick={() =>
+                    window.history.length === 1
+                        ? navigate("/")
+                        : window.history.back()
+                }>
                 <Icon
                     name="caretLeft"
                     color="black"


### PR DESCRIPTION
# Closes/Fixes/Resolves
closes: #181 

### <!-- Any of the keywords: Closes/Fixes/Resolves followed by #issue_id (should be separated by a space only) -->

# Explain the feature/fix
This is a temporary fix for #181. The best solution is to migrate to React router so that we can use react-router-last-location library to get the last location.